### PR TITLE
README: add Generate Placeholders For Existing Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ yarn add strapi-plugin-placeholder
 
 ## 🔧 Configuration
 
+### Enable The Plugin
+
 Open or create the file `config/plugins.js` and enable the plugin by adding the following snippet:
 
 ```js
@@ -41,3 +43,50 @@ module.exports = {
 ```
 
 For more information regarding the `size` param, refer to the [Plaiceholder docs](https://plaiceholder.co/docs/usage).
+
+### Generate Placeholders For Existing Images
+
+Create the file `database/migrations/generate-placeholders-for-existing-images.js` with the following content:
+
+```js
+'use strict';
+
+const FILES_TABLE = 'files';
+const BATCH_SIZE = 1000;
+
+async function up(trx) {
+  let lastId = 0;
+
+  while (true) {
+    const files = await trx
+      .select(['id', 'url'])
+      .from(FILES_TABLE)
+      .whereNot('url', null)
+      .andWhereLike('mime', 'image/%')
+      .andWhere('placeholder', null)
+      .andWhere('id', '>', lastId)
+      .orderBy('id', 'asc')
+      .limit(BATCH_SIZE);
+
+    for (const file of files) {
+      const placeholder = await strapi
+        .plugin('placeholder')
+        .service('placeholder')
+        .generate(file.url);
+
+      if (placeholder)
+        await trx.update('placeholder', placeholder).from(FILES_TABLE).where('id', file.id);
+    }
+
+    if (files.length < BATCH_SIZE) {
+      break;
+    }
+
+    lastId = files[files.length - 1].id;
+  }
+}
+
+async function down() {}
+
+module.exports = { up, down };
+```


### PR DESCRIPTION
I updated the README file to explain how to generate placeholders for existing images, as described in [issue #1](https://github.com/WalkingPizza/strapi-plugin-placeholder/issues/1).