### PR TITLE
Manually get file `url` when undefined

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -6,10 +6,19 @@ module.exports = ({ strapi }) => {
   /* Generate a placeholder when a new image is uploaded or updates */
 
   const generatePlaceholder = async (event) => {
-    const { data } = event.params;
+    const { data, where } = event.params;
     if (!canGeneratePlaceholder(data)) return;
-    data.placeholder = await getService(strapi, 'placeholder').generate(data.url);
+    let url = data.url || await getFileUrlById(where?.id)
+    if (!url) return;
+    data.placeholder = await getService(strapi, 'placeholder').generate(url);
   };
+
+  /* The `beforeUpdate` lifecycle doesn’t have the file’s `url` attribute populated so we'll manually fetch it. */
+  const getFileUrlById = async (id) => {
+    if (!id) return
+    const file = await strapi.service('plugin::upload.upload').findOne(id)
+    return file?.url
+  }
 
   strapi.db.lifecycles.subscribe({
     models: ['plugin::upload.file'],


### PR DESCRIPTION
`beforeUpdate` has no `url` in `event.params.data` when using the local image provider (not tested with other providers), with this commit the `url` is manually fetched from the database when so.