### PR TITLE
Fix plugin not updating placeholder or throwing 500 on file update. Mark Node 18 as supported.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "displayName": "Placeholder"
   },
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=12.x.x <=18.x.x",
     "npm": ">=6.0.0"
   },
   "keywords": [

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -6,7 +6,16 @@ module.exports = ({ strapi }) => {
   /* Generate a placeholder when a new image is uploaded or updates */
 
   const generatePlaceholder = async (event) => {
-    const { data } = event.params;
+    const { data, where } = event.params;
+
+    if(!data.url || !data.mime) {
+      // If the returned data is missing a url or mime property (probably because we're doing an update)
+      // then we'll need to pull these values from the upload.file plugin and merge them in.
+      const file = await strapi.entityService.findOne("plugin::upload.file", where.id);
+      data.url = data.url ?? file.url;
+      data.mime = data.mime ?? file.mime;
+    }
+
     if (!canGeneratePlaceholder(data)) return;
     data.placeholder = await getService(strapi, 'placeholder').generate(data.url);
   };

--- a/server/utils.js
+++ b/server/utils.js
@@ -10,8 +10,15 @@ const mimeTypes = require('mime-types');
  */
 
 const canGeneratePlaceholder = (file) => {
-  if (!file.mime) file.mime = mimeTypes.lookup(file.name);
-  return file.mime?.startsWith('image/');
+  if (!file.mime) {
+    // Only lookup the mime if file lacks the prop.
+    const lookedUpMime = mimeTypes.lookup(file.name);
+    if(lookedUpMime) { // lookedUpMime can return false if it failed to match
+      file.mime = lookedUpMime;
+    }
+  }
+
+  return file.mime?.startsWith('image/') && file.url;
 };
 
 /**


### PR DESCRIPTION
When Strapi does a file update, it doesn't provide the URL or MIME props needed to [re]-generate a placeholder. I've added a bit of extra code to generatePlaceholder to fetch the original file's info and to populate these fields if they are missing before being fed to canGeneratePlaceholder, allowing placeholders to be updated when a file is updated, not just created.

I've also fixed a type error in canGeneratePlaceholder should mimeTypes.lookup fail - something that was causing 500 errors when updating a file - and I've updated package.json to also support Node 18.x, as the plugin seems to work without issue.

Fixes #2, #6 and #11