### PR TITLE
Update node engine to use LTS versions 18 (and soon 20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "displayName": "Placeholder"
   },
   "engines": {
-    "node": ">=12.x.x <=18.x.x",
+    "node": ">=18.x.x <=20.x.x",
     "npm": ">=6.0.0"
   },
   "keywords": [


### PR DESCRIPTION
With Active LTS starting for v20 the 24th of October, it would be good to update the engine config in package.json. This way we won't run into an incompatibility error when install the package. Also since last September v16 is EOL.
 
```bash
error The engine "node" is incompatible with this module. Expected version ">=12.x.x <=18.x.x". Got "20.5.1"
error Found incompatible module.
```

https://nodejs.dev/en/about/releases
![image](https://github.com/WalkingPizza/strapi-plugin-placeholder/assets/31662805/767d563f-8cc6-40c7-b40a-2e59ac2dda46)
